### PR TITLE
Fix incompatible_no_support_tools_in_action_inputs

### DIFF
--- a/antlr/antlr4.bzl
+++ b/antlr/antlr4.bzl
@@ -86,7 +86,7 @@ def _generate(ctx):
 
     ctx.actions.run(
         arguments = [args],
-        inputs = ctx.files.srcs + ctx.files.imports + tool_inputs,
+        inputs = ctx.files.srcs + ctx.files.imports,
         outputs = [srcjar],
         mnemonic = "ANTLR4",
         executable = ctx.executable._tool,
@@ -103,6 +103,7 @@ def _generate(ctx):
         },
         input_manifests = input_manifests,
         progress_message = "Processing ANTLR 4 grammars",
+        tools = tool_inputs
     )
 
 


### PR DESCRIPTION
Fixes `bazel` upcoming incompatible changes (found by `--all_incompatible_changes`)