### PR TITLE
Experimental support for Rust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bazel-*/
 .project
 .settings/
 /bin/
+.ijwb

--- a/antlr/impl.bzl
+++ b/antlr/impl.bzl
@@ -66,8 +66,6 @@ def antlr(version, ctx, args):
         ctx.actions.write(
             output = crate_wrapper,
             content = """
-#![feature(try_blocks)]
-
 extern crate antlr_rust;
 
 #[path = "{pkg}/{grammar}lexer.rs"] pub mod {grammar}lexer;

--- a/antlr/impl.bzl
+++ b/antlr/impl.bzl
@@ -33,6 +33,7 @@ def antlr(version, ctx, args):
     headers = []
     cc = ctx.attr.language == CPP or ctx.attr.language == C or ctx.attr.language == OBJC
     output_type = None
+    crate_wrapper = None
 
     if ctx.attr.language == "Java":
         output_type = "srcjar"
@@ -115,7 +116,8 @@ extern crate antlr_rust;
         progress_message = "Processing ANTLR {} grammars".format(version),
         tools = tool_inputs,
     )
-    outputs.append(crate_wrapper)
+    if crate_wrapper:
+        outputs.append(crate_wrapper)
 
     # for C/C++ we add the generated headers to the compilation context
     if cc:

--- a/antlr/lang.bzl
+++ b/antlr/lang.bzl
@@ -17,4 +17,4 @@ def supported():
     Returns:
       the list of supported languages.
     """
-    return [C, CPP, GO, JAVA, OBJC, PYTHON, PYTHON2, PYTHON3]
+    return [C, CPP, GO, JAVA, OBJC, PYTHON, PYTHON2, PYTHON3, RUST]

--- a/antlr/repositories.bzl
+++ b/antlr/repositories.bzl
@@ -69,8 +69,8 @@ PACKAGES = {
     },
     "antlr4_tool": {
         "4.8.2-rust": {
-            "path": "https://github.com/rrevenantt/antlr4rust/releases/download/antlr4-4.8-2-Rust-0.2/antlr4-4.8-2-SNAPSHOT-complete.jar",
-            "sha256": "00b7690be39cf4a4afeae7a227e6d2d35ce0f70b788ab51f9af897db44084c76",
+            "path": "https://github.com/rrevenantt/antlr4rust/releases/download/antlr4-4.8-2-Rust0.3.0-beta/antlr4-4.8-2-SNAPSHOT-complete.jar",
+            "sha256": "d23d7b0006f7477243d2d85c54632baa1932a5e05588e0c2548dbe3dd69f4637",
         },
         "4.8": {
             "path": "org/antlr/antlr4/4.8/antlr4-4.8.jar",

--- a/antlr/repositories.bzl
+++ b/antlr/repositories.bzl
@@ -3,7 +3,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load(":lang.bzl", "C", "CPP", "GO", "JAVA", "OBJC", "PYTHON", "PYTHON2", "PYTHON3", supportedLanguages = "supported")
 
-v4 = [4, "4.7.1", "4.7.2", "4.8"]
+v4 = [4, "4.7.1", "4.7.2", "4.8", "4.8.2-rust"]
 v4_opt = [4, "4.7.1", "4.7.2", "4.7.3", "4.7.4"]
 v3 = [3, "3.5.2"]
 v2 = [2, "2.7.7"]
@@ -68,6 +68,10 @@ PACKAGES = {
         },
     },
     "antlr4_tool": {
+        "4.8.2-rust": {
+            "path": "https://github.com/rrevenantt/antlr4rust/releases/download/antlr4-4.8-2-Rust-0.2/antlr4-4.8-2-SNAPSHOT-complete.jar",
+            "sha256": "00b7690be39cf4a4afeae7a227e6d2d35ce0f70b788ab51f9af897db44084c76",
+        },
         "4.8": {
             "path": "org/antlr/antlr4/4.8/antlr4-4.8.jar",
             "sha256": "6e4477689371f237d4d8aa40642badbb209d4628ccdd81234d90f829a743bac8",
@@ -181,6 +185,8 @@ def rules_antlr_dependencies(*versionsAndLanguages):
         for version in sorted(versions, key = _toString):
             if version == 4 or version == "4.8":
                 _antlr48_dependencies(languages)
+            elif version == "4.8.2-rust":
+                _antlr482_rust_dependencies(languages)
             elif version == "4.7.2":
                 _antlr472_dependencies(languages)
             elif version == "4.7.1":
@@ -216,6 +222,19 @@ def rules_antlr_optimized_dependencies(version):
         fail('Integer version \'{}\' no longer valid. Use semantic version "{}" instead.'.format(version, ".".join(str(version).elems())), attr = "version")
     else:
         fail('Unsupported ANTLR version provided: "{0}". Currently supported are: {1}'.format(version, v4_opt), attr = "version")
+
+def _antlr482_rust_dependencies(languages):
+    _antlr4_dependencies(
+        "4.8",
+        languages,
+        {
+            "antlr4_runtime": "4.8",
+            "antlr4_tool": "4.8.2-rust",
+            "antlr3_runtime": "3.5.2",
+            "stringtemplate4": "4.3",
+            "javax_json": "1.0.4",
+        },
+    )
 
 def _antlr48_dependencies(languages):
     _antlr4_dependencies(

--- a/src/main/java/org/antlr/bazel/AntlrRules.java
+++ b/src/main/java/org/antlr/bazel/AntlrRules.java
@@ -290,6 +290,10 @@ public class AntlrRules
 
                                 break;
                             }
+                            case RUST:
+                            {
+                                break;
+                            }
                         }
 
                         // source files should be stored below their corresponding

--- a/src/main/java/org/antlr/bazel/Language.java
+++ b/src/main/java/org/antlr/bazel/Language.java
@@ -370,6 +370,36 @@ enum Language
         {
             return layout;
         }
+    },
+    RUST
+    {
+        @Override
+        public String toPath(String namespace)
+        {
+            return null;
+        }
+
+
+        @Override
+        public String toId(Path path)
+        {
+            return null;
+        }
+
+
+        @Override
+        public Namespace detectNamespace(String grammar)
+        {
+            return null;
+        }
+
+
+        @Override
+        public DirectoryLayout getLayout()
+        {
+            return new DirectoryLayout("flat");
+        }
+
     };
 
     private static final Pattern OPTIONS = Pattern.compile("options\\s*\\{.*?\\}",
@@ -522,6 +552,10 @@ enum Language
             case "Swift" :
             {
                 return SWIFT;
+            }
+            case "Rust" :
+            {
+                return RUST;
             }
 
             default :


### PR DESCRIPTION
Experimental support for Rust based compiler from [here](https://github.com/rrevenantt/antlr4/tree/rust-target) (runtime can be found [here](https://github.com/rrevenantt/antlr4rust))

Due to [an issue in `rules_rust`](bazelbuild/rules_rust#963), we need to output a set of `*.rs` files instead of a directory with those file (as rest of the implementations do)